### PR TITLE
Add support for psr/http-client

### DIFF
--- a/src/Http/HttpClient.php
+++ b/src/Http/HttpClient.php
@@ -17,6 +17,7 @@ if (!interface_exists('Http\Client\HttpClient')) {
 // phpcs:enable
 
 use Http\Client\HttpClient as HttpPlugClientInterface;
+use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Windwalker\Http\Request\Request;
@@ -31,7 +32,7 @@ use Windwalker\Uri\UriHelper;
  *
  * @since  2.1
  */
-class HttpClient implements HttpClientInterface, HttpPlugClientInterface
+class HttpClient implements HttpClientInterface, HttpPlugClientInterface, ClientInterface
 {
     /**
      * Property options.
@@ -108,7 +109,7 @@ class HttpClient implements HttpClientInterface, HttpPlugClientInterface
      *
      * @return  ResponseInterface
      */
-    public function send(RequestInterface $request)
+    public function send(RequestInterface $request): ResponseInterface
     {
         $transport = $this->getTransport();
 

--- a/src/Http/composer.json
+++ b/src/Http/composer.json
@@ -6,8 +6,9 @@
     "homepage": "https://github.com/ventoviro/windwalker-http",
     "license": "LGPL-2.0-or-later",
     "require": {
-        "php": ">=5.5.9",
+        "php": "^7.0",
         "psr/http-message": "1.*",
+        "psr/http-client": "^0.1",
         "windwalker/uri": "~3.0",
         "composer/ca-bundle": "^1.1"
     },


### PR DESCRIPTION
I know this PR maybe premature for you and you are not ready to drop PHP5 support. Im soon about to open the official vote for PSR-18. And I wanted to show how it will effect windwalker. 

@asika32764 Please add some comments if you are happy with the PSR draft. 


See the specification: https://github.com/php-fig/fig-standards/blob/master/proposed/http-client/http-client.md
Read the blog post: https://medium.com/php-fig/the-http-client-psr-9c2535132980
FYI: Httplug will release a version 2.0 that drops PHP5. See: https://github.com/php-http/httplug/compare/master...2.x